### PR TITLE
v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spatial v0.5.0 ![Badge](https://github.com/jbschwartz/spatial/actions/workflows/ci.yml/badge.svg)
+# Spatial v0.6.0 ![Badge](https://github.com/jbschwartz/spatial/actions/workflows/ci.yml/badge.svg)
 
 A Python library for representing and working with 3D objects.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spatial"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Python library for representing and working with 3D objects."
 authors = ["James Schwartz"]
 

--- a/spatial/intersection.py
+++ b/spatial/intersection.py
@@ -12,7 +12,7 @@ class Intersection(namedtuple("Intersection", "t obj")):
     # This could maybe be implemented with a `previous` attribute on the tuple
     # i.e. __new__(..., previous: 'Intersection')
     def __new__(cls, t: Optional[float], obj: Optional[Any]):
-        """Construct a new intersection given a parametic location and the intersected object."""
+        """Construct a new intersection given a parametric location and the intersected object."""
         if t is not None and t < 0:
             raise ValueError("Intersection can not be behind ray")
         return super().__new__(cls, t, obj)

--- a/spatial/kdtree.py
+++ b/spatial/kdtree.py
@@ -39,8 +39,8 @@ class KDTreeNode:
 
             self.children.append(node)
 
-        # Interrior nodes to the KDTree should not have any facets (only leaf nodes should).
-        # If we've gotten this far, this node is an interrior node
+        # Interior nodes to the KDTree should not have any facets (only leaf nodes should).
+        # If we've gotten this far, this node is an interior node.
         self.facets = []
 
     def can_branch(self, depth: int) -> bool:
@@ -69,7 +69,7 @@ class KDTreeNode:
 
         for facet in self.facets:
             # Check minimum bound on left and maximum bound on right.
-            # This covers both scenarios: facets belonging to one side only or both sides
+            # This covers both scenarios: facets belonging to one side only or both sides.
             if facet.aabb.min[plane_axis] < plane_value:
                 left.append(facet)
             if facet.aabb.max[plane_axis] > plane_value:

--- a/spatial/matrix4.py
+++ b/spatial/matrix4.py
@@ -1,3 +1,4 @@
+import math
 from typing import Iterable
 
 from .dual import Dual
@@ -22,6 +23,20 @@ class Matrix4:
             self.elements = elements
         else:
             self.elements = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+
+    @classmethod
+    def from_basis(cls, x: Vector3, y: Vector3, z: Vector3, origin: Vector3 = None):
+        """Construct a quaternion from three mutually perpendicular basis vectors."""
+        assert all(
+            [x.is_perpendicular_to(y), y.is_perpendicular_to(z), z.is_perpendicular_to(x)]
+        ), "All basis vectors must be mutually perpendicular"
+
+        assert all(
+            [math.isclose(x.length(), 1), math.isclose(y.length(), 1), math.isclose(z.length(), 1)]
+        ), "All basis vectors must be unit length"
+
+        o = origin or Vector3()
+        return cls([x.x, x.y, x.z, 0, y.x, y.y, y.z, 0, z.x, z.y, z.z, 0, o.x, o.y, o.z, 1])
 
     @classmethod
     def from_transform(cls, transform: Transform) -> "Matrix4":

--- a/spatial/quaternion.py
+++ b/spatial/quaternion.py
@@ -101,6 +101,10 @@ class Quaternion(Swizzler):
 
         return NotImplemented
 
+    def __format__(self, spec: str = "") -> str:
+        """Return the string representation following the format specification component-wise."""
+        return f"({self.r:{spec}}, {self.x:{spec}}, {self.y:{spec}}, {self.z:{spec}})"
+
     def __getitem__(self, index: int) -> float:
         """Return the value of the component at the provided index."""
         components = ["r", "x", "y", "z"]
@@ -147,7 +151,7 @@ class Quaternion(Swizzler):
 
     def __str__(self) -> str:
         """Return the string representation of this quaternion."""
-        return f"({self.r}, {self.x}, {self.y}, {self.z})"
+        return format(self, "")
 
     def __sub__(self, other: "Quaternion") -> "Quaternion":
         """Return a quaternion with the component-wise difference of this and the other."""

--- a/spatial/quaternion.py
+++ b/spatial/quaternion.py
@@ -28,6 +28,31 @@ class Quaternion(Swizzler):
 
         return cls(math.cos(half_angle), axis.x, axis.y, axis.z)
 
+    @classmethod
+    def from_basis(cls, x: Vector3, y: Vector3, z: Vector3):
+        """Construct a quaternion from three mutually perpendicular basis vectors."""
+        assert all(
+            [x.is_perpendicular_to(y), y.is_perpendicular_to(z), z.is_perpendicular_to(x)]
+        ), "All basis vectors must be mutually perpendicular"
+
+        # Implementing the algorithm described in "Converting a Rotation Matrix to a Quaternion" by
+        # Mike Day, Insomniac Games
+        if z.z < 0:
+            if x.x > y.y:
+                t = 1 + x.x - y.y - z.z
+                quaternion = cls(y.z - z.y, t, x.y + y.x, z.x + x.z)
+            else:
+                t = 1 - x.x + y.y - z.z
+                quaternion = cls(z.x - x.z, x.y + y.x, t, y.z + z.y)
+        else:
+            if x.x < -y.y:
+                t = 1 - x.x - y.y + z.z
+                quaternion = cls(x.y - y.x, z.x + x.z, y.z + z.y, t)
+            else:
+                t = 1 + x.x + y.y + z.z
+                quaternion = cls(t, y.z - z.y, z.x - x.z, x.y - y.x)
+
+        return (0.5 / math.sqrt(t)) * quaternion
 
     @classmethod
     def from_euler(cls, angles: List[float], axes: Axes, order: Order) -> "Quaternion":

--- a/spatial/quaternion.py
+++ b/spatial/quaternion.py
@@ -158,13 +158,14 @@ class Quaternion(Swizzler):
         """Return the length of the quaternion."""
         return math.sqrt(self.r**2 + self.x**2 + self.y**2 + self.z**2)
 
-    def normalize(self) -> None:
+    def normalize(self) -> "Quaternion":
         """Normalize the quaternion instance (i.e. norm of one)."""
         norm = self.norm()
         self.r /= norm
         self.x /= norm
         self.y /= norm
         self.z /= norm
+        return self
 
     def rotate(self, vector: Vector3) -> Vector3:
         """Return the provided vector rotated by this quaternion."""

--- a/spatial/quaternion.py
+++ b/spatial/quaternion.py
@@ -21,8 +21,13 @@ class Quaternion(Swizzler):
     def from_axis_angle(cls, axis: Vector3, angle: float) -> "Quaternion":
         """Construct a quaternion from an axis and angle (in radians)."""
         half_angle = angle / 2
-        axis = math.sin(half_angle) * axis
+        try:
+            axis = math.sin(half_angle) * axis.normalize()
+        except ZeroDivisionError:
+            axis = Vector3()
+
         return cls(math.cos(half_angle), axis.x, axis.y, axis.z)
+
 
     @classmethod
     def from_euler(cls, angles: List[float], axes: Axes, order: Order) -> "Quaternion":

--- a/spatial/ray.py
+++ b/spatial/ray.py
@@ -13,7 +13,7 @@ class Ray:
         try:
             self.direction = direction.normalize()
         except ZeroDivisionError:
-            raise ValueError("The direction vectory must be non-zero") from ZeroDivisionError
+            raise ValueError("The direction vector must be non-zero") from ZeroDivisionError
 
     def __str__(self) -> str:
         """Return the string representation of this ray."""

--- a/spatial/transform.py
+++ b/spatial/transform.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Union
+from typing import Iterable, Tuple, Union
 
 from . import dual, quaternion
 from .vector3 import Vector3
@@ -59,6 +59,15 @@ class Transform:
         return NotImplemented
 
     __rmul__ = __mul__
+
+    @property
+    def basis(self) -> Tuple[Vector3, Vector3, Vector3]:
+        """Return orthonormal basis vectors for the given transformation."""
+        return (
+            self.transform(Vector3.X(), as_type="vector"),
+            self.transform(Vector3.Y(), as_type="vector"),
+            self.transform(Vector3.Z(), as_type="vector"),
+        )
 
     @property
     def rotation(self) -> Quaternion:

--- a/spatial/vector3.py
+++ b/spatial/vector3.py
@@ -128,6 +128,10 @@ class Vector3(Swizzler):
 
         return NotImplemented
 
+    def is_perpendicular_to(self, other: "Vector3", tolerance: float = 0.00001) -> bool:
+        """Return True if the vector is perpendicular to the other vector."""
+        return math.isclose(self * other, 0, abs_tol=tolerance)
+
     def is_unit(self, tolerance: float = 0.00001) -> bool:
         """Return True if the vector has unit length (within a given tolerance)."""
         return math.isclose(self.length_sq(), 1.0, abs_tol=tolerance)

--- a/spatial/vector3.py
+++ b/spatial/vector3.py
@@ -54,6 +54,10 @@ class Vector3(Swizzler):
 
         return NotImplemented
 
+    def __format__(self, spec: str = "") -> str:
+        """Return the string representation following the format specification component-wise."""
+        return f"({self.x:{spec}}, {self.y:{spec}}, {self.z:{spec}})"
+
     def __getitem__(self, index: int) -> float:
         """Return the value of the component at the provided index."""
         components = ["x", "y", "z"]
@@ -110,7 +114,7 @@ class Vector3(Swizzler):
 
     def __str__(self) -> str:
         """Return the string representation of this vector."""
-        return f"({self.x}, {self.y}, {self.z})"
+        return format(self, "")
 
     def __sub__(self, other: "Vector3") -> "Vector3":
         """Return a vector with the component-wise difference of this vector and the other."""

--- a/spatial/vector3.py
+++ b/spatial/vector3.py
@@ -94,7 +94,7 @@ class Vector3(Swizzler):
         return Vector3(-self.x, -self.y, -self.z)
 
     def __repr__(self) -> str:
-        """Return a string representatoin of this vector's construction."""
+        """Return a string representation of this vector's construction."""
         return f"Vector3(x={self.x}, y={self.y}, z={self.z})"
 
     __rmul__ = __mul__

--- a/test/test_dual.py
+++ b/test/test_dual.py
@@ -56,7 +56,7 @@ class TestDual(unittest.TestCase):
         self.assertTrue(str(self.r1) in str(self.dq1))
         self.assertTrue(str(self.d1) in str(self.dq1))
 
-    def test__sub__subracts_two_duals(self) -> None:
+    def test__sub__subtracts_two_duals(self) -> None:
         self.assertEqual(self.dq1 - self.dq2, Dual(self.r1 - self.r2, self.d1 - self.d2))
 
     def test__sub__returns_notimplemented_for_incompatible_types(self) -> None:

--- a/test/test_facet.py
+++ b/test/test_facet.py
@@ -76,7 +76,7 @@ class TestFacet(unittest.TestCase):
         for actual, vertex in zip(scaled_facet.vertices, self.vertices):
             self.assertEqual(actual, 2 * vertex)
 
-    def test_transform_returns_a_tranformed_facet(self) -> None:
+    def test_transform_returns_a_transformed_facet(self) -> None:
         t = Transform.from_axis_angle_translation(axis=Vector3.Z(), angle=math.radians(90))
         transformed_facet = self.facet.transform(t)
 

--- a/test/test_matrix4.py
+++ b/test/test_matrix4.py
@@ -25,6 +25,36 @@ class TestMatrix4(unittest.TestCase):
         with self.assertRaises(TypeError):
             Matrix4([0] * 15)
 
+    def test_from_basis_constructs_a_matrix_from_three_basis_vectors_and_an_origin(self) -> None:
+        vectors = [
+            Vector3(1, 2, 3).normalize(),
+            Vector3(-4, -7, 6).normalize(),
+            Vector3(),
+            Vector3(-1, -2, -3),
+        ]
+        vectors[2] = (vectors[0] % vectors[1]).normalize()
+
+        matrix = Matrix4.from_basis(*vectors)
+
+        self.assertEqual(Vector3(*matrix.elements[0:3]), vectors[0])
+        self.assertEqual(Vector3(*matrix.elements[4:7]), vectors[1])
+        self.assertEqual(Vector3(*matrix.elements[8:11]), vectors[2])
+        self.assertEqual(Vector3(*matrix.elements[12:15]), vectors[3])
+
+    def test_from_basis_raises_for_non_orthonormal_vectors(self) -> None:
+        vectors = [Vector3(1, 2, 3), Vector3(4, 6, 7), Vector3(8, 9, 0), Vector3(-1, -2, -3)]
+        with self.assertRaises(AssertionError):
+            _ = Matrix4.from_basis(*vectors)
+
+        vectors = [
+            2 * Vector3.X(),
+            2 * Vector3.Y(),
+            2 * Vector3.Z(),
+            Vector3(-1, -2, -3),
+        ]
+        with self.assertRaises(AssertionError):
+            _ = Matrix4.from_basis(*vectors)
+
     def test_from_transform_constructs_a_matrix_from_a_dual_quaternion(self) -> None:
         for value, expected in zip(Matrix4.from_transform(self.transform).elements, self.expected):
             self.assertAlmostEqual(value, expected)

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -105,7 +105,7 @@ class TestQuaternion(unittest.TestCase):
         self.assertTrue(str(self.q.y) in str(self.q))
         self.assertTrue(str(self.q.z) in str(self.q))
 
-    def test__sub__subracts_two_quaternions(self) -> None:
+    def test__sub__subtracts_two_quaternions(self) -> None:
         self.assertEqual(self.q - self.r, Quaternion(-3, 5, 1, 5))
 
     def test__sub__returns_notimplemented_for_incompatible_types(self) -> None:

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -1,7 +1,7 @@
 import math
 import unittest
 
-from spatial import Quaternion, Vector3, quaternion
+from spatial import Quaternion, Transform, Vector3, quaternion
 from spatial.euler import Axes, Order
 
 
@@ -18,6 +18,21 @@ class TestQuaternion(unittest.TestCase):
     def test__init__accepts_component_values(self) -> None:
         self.assertEqual(Quaternion(1, *self.axis), Quaternion(1, 1, 2, 3))
 
+    def test_from_basis_constructs_a_quaternion_from_axis_angle(self) -> None:
+        standard_basis = [Vector3.X(), Vector3.Y(), Vector3.Z()]
+        for angle in [math.pi / 4, 3 * math.pi / 4, 5 * math.pi / 4, 7 * math.pi / 4]:
+            with self.subTest(f"Angle: {math.degrees(angle)}"):
+                transform = Transform.from_axis_angle_translation(Vector3(1, -2, 3), angle)
+                actual = Quaternion.from_basis(*transform.basis)
+
+                # Q = -Q for all quaternions.
+                try:
+                    self.assertAlmostEqual(transform.rotation, actual)
+                except AssertionError:
+                    self.assertAlmostEqual(-transform.rotation, actual)
+
+                for standard_vector, actual_vector in zip(standard_basis, actual):
+                    self.assertTrue(actual_vector, actual.rotate(standard_vector))
 
     def test_from_axis_angle_constructs_a_quaternion_from_axis_angle(self) -> None:
         angle = math.radians(30)

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -18,10 +18,14 @@ class TestQuaternion(unittest.TestCase):
     def test__init__accepts_component_values(self) -> None:
         self.assertEqual(Quaternion(1, *self.axis), Quaternion(1, 1, 2, 3))
 
+
     def test_from_axis_angle_constructs_a_quaternion_from_axis_angle(self) -> None:
         angle = math.radians(30)
         c = math.cos(angle / 2)
         s = math.sin(angle / 2)
+
+        self.axis.normalize()
+
         expected = Quaternion(c, s * self.axis.x, s * self.axis.y, s * self.axis.z)
         self.assertEqual(Quaternion.from_axis_angle(self.axis, angle), expected)
 
@@ -141,6 +145,15 @@ class TestQuaternion(unittest.TestCase):
     def test_rotate_returns_a_rotated_vector(self) -> None:
         q = Quaternion.from_axis_angle(Vector3.X(), math.radians(90))
         self.assertAlmostEqual(q.rotate(Vector3(1, 0, 1)), Vector3(1, -1, 0))
+
+    def test_rotate_returns_a_rotated_vector_without_scaling_it(self) -> None:
+        q = Quaternion.from_axis_angle(6 * Vector3.X(), math.radians(90))
+
+        result = q.rotate(Vector3(1, 0, 1))
+        expected = Vector3(1, -1, 0)
+
+        self.assertAlmostEqual(result, expected)
+        self.assertAlmostEqual(result.length(), expected.length())
 
     def test_quaternion_conjugate_returns_the_conjugate(self) -> None:
         result = quaternion.conjugate(self.q)

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -47,7 +47,7 @@ class TestRay(unittest.TestCase):
             self.ray.evaluate(2), self.ray.origin + 2 * vector3.normalize(self.ray.direction)
         )
 
-    def test_tranform_transforms_the_rays_origin_and_direction(self) -> None:
+    def test_transform_transforms_the_rays_origin_and_direction(self) -> None:
         r = Ray(Vector3(1, 1, 0), Vector3(1, 1, 0))
         t = Transform.from_axis_angle_translation(
             axis=Vector3.Z(), angle=math.radians(-45), translation=Vector3(-math.sqrt(2), 0, 0)

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -2,6 +2,7 @@ import math
 import unittest
 
 from spatial import Quaternion, Transform, Vector3
+from spatial.euler import Axes, Order
 
 
 class TestTransform(unittest.TestCase):
@@ -68,6 +69,19 @@ class TestTransform(unittest.TestCase):
 
     def test__mul__returns_notimplemented_for_incompatible_types(self) -> None:
         self.assertTrue(self.both.__mul__("string") == NotImplemented)
+
+    def test_basis_returns_the_transformations_basis_vectors(self) -> None:
+        quaternion = Quaternion.from_euler(
+            [math.radians(45), math.radians(-45), 0], Axes.XYX, Order.INTRINSIC
+        )
+
+        transform = Transform.from_orientation_translation(quaternion)
+        basis = transform.basis
+
+        a = 1 / math.sqrt(2)
+        self.assertAlmostEqual(Vector3(a, -0.5, 0.5), basis[0])
+        self.assertAlmostEqual(Vector3(0, a, a), basis[1])
+        self.assertAlmostEqual(Vector3(-a, -0.5, 0.5), basis[2])
 
     def test_rotation_returns_the_rotation_component_of_the_transform(self) -> None:
         self.assertEqual(self.pureRotate.rotation, self.pureRotate.dual.r)

--- a/test/test_vector3.py
+++ b/test/test_vector3.py
@@ -101,6 +101,10 @@ class TestVector3(unittest.TestCase):
     def test__truediv__returns_notimplemented_for_incompatible_types(self) -> None:
         self.assertTrue(self.v1.__truediv__("string") == NotImplemented)
 
+    def test_is_perpendicular_to_returns_true_for_perpendicular_vectors(self) -> None:
+        self.assertFalse(self.v1.is_perpendicular_to(self.v2))
+        self.assertTrue(Vector3.Z().is_perpendicular_to(Vector3.X()))
+
     def test_is_unit_returns_true_for_vectors_of_length_one(self) -> None:
         unit_vector = normalize(self.v1)
         self.assertFalse(self.v1.is_unit())

--- a/test/test_vector3.py
+++ b/test/test_vector3.py
@@ -88,7 +88,7 @@ class TestVector3(unittest.TestCase):
         self.assertTrue(str(self.v1.y) in str(self.v1))
         self.assertTrue(str(self.v1.z) in str(self.v1))
 
-    def test__sub__subracts_two_vectors(self) -> None:
+    def test__sub__subtracts_two_vectors(self) -> None:
         self.assertEqual(self.v1 - self.v2, Vector3(-3, 7, -6))
 
     def test__sub__returns_notimplemented_for_incompatible_types(self) -> None:


### PR DESCRIPTION
Version 0.6.0:

- Implement `Vector3.is_perpendicular`, `Transform.basis`, `Quaternion.from_basis`, `Matrix4.from_basis`.
- Implement `Vector3` and `Quaternion` format magic method.
- Return the Quaternion from `Quaternion.normalize` method for chaining.
- Fix bug where Quaternion's constructed from axis and angle scaled vectors while rotating them.
- Fix spelling and punctuation.