### PR TITLE
v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spatial v0.6.1 ![Badge](https://github.com/jbschwartz/spatial/actions/workflows/ci.yml/badge.svg)
+# Spatial v0.6.2 ![Badge](https://github.com/jbschwartz/spatial/actions/workflows/ci.yml/badge.svg)
 
 A Python library for representing and working with 3D objects.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spatial"
-version = "0.6.1"
+version = "0.6.2"
 description = "A Python library for representing and working with 3D objects."
 authors = ["James Schwartz"]
 

--- a/spatial/quaternion.py
+++ b/spatial/quaternion.py
@@ -229,10 +229,12 @@ def slerp(q1: Quaternion, q2: Quaternion, alpha: float, shortest_path: bool = Tr
         q2 = -q2
         dot = q1.dot(q2)
 
-    # Clamp dot between [1, -1] to avoid domain errors in the subsequent arccosine.
-    dot = min(1, max(-1, dot))
+    # If the dot is 1 or -1, then theta is zero and the starting point should be returned.
+    if dot >= 1 or dot <= -1:
+        return q1
 
-    theta = math.acos(dot) * alpha
+    # Compute the half angle between the two quaternions and scale based on the parameter.
+    theta = alpha * math.acos(dot)
 
     q = (q2 - (q1 * dot)).normalize()
 

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -182,5 +182,19 @@ class TestQuaternion(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_quaternion_slerp_returns_the_endpoints_for_0_and_1(self) -> None:
-        self.assertAlmostEqual(quaternion.slerp(self.q.normalize(), self.r.normalize(), 0), self.q)
-        self.assertAlmostEqual(quaternion.slerp(self.q.normalize(), self.r.normalize(), 1), self.r)
+        self.q.normalize()
+        self.r.normalize()
+
+        self.assertAlmostEqual(quaternion.slerp(self.q, self.r, 0), self.q)
+        self.assertAlmostEqual(quaternion.slerp(self.q, self.r, 1), self.r)
+
+    def test_quaternion_slerp_returns_the_endpoints_for_identical_quaternions(self) -> None:
+        self.q.normalize()
+
+        steps = 10
+        for index in range(steps):
+            value = index / (steps - 1)
+            with self.subTest(case=value):
+                self.assertAlmostEqual(quaternion.slerp(self.q, self.q, value), self.q)
+                # This example causes a division by zero (fixed in v0.6.2).
+                self.assertAlmostEqual(quaternion.slerp(self.I, self.I, value), self.I)


### PR DESCRIPTION
Version 0.6.2:

- Fix bug in `slerp` that caused division by zero for identical endpoints.