### PR TITLE
v0.6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 .vscode
 .mypy_cache
 .ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spatial v0.6.2 ![Badge](https://github.com/jbschwartz/spatial/actions/workflows/ci.yml/badge.svg)
+# Spatial v0.6.3 ![Badge](https://github.com/jbschwartz/spatial/actions/workflows/ci.yml/badge.svg)
 
 A Python library for representing and working with 3D objects.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,0 @@
-name: spatial
-channels:
-  - defaults
-dependencies:
-  - python=3.8
-  - pip
-  - pip:
-    - poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spatial"
-version = "0.6.2"
+version = "0.6.3"
 description = "A Python library for representing and working with 3D objects."
 authors = ["James Schwartz"]
 

--- a/spatial/__init__.py
+++ b/spatial/__init__.py
@@ -9,6 +9,7 @@ from .intersection import Intersection
 from .kdtree import KDTreeNode
 from .matrix4 import Matrix4
 from .mesh import Mesh
+from .parameters import parameters
 from .quaternion import Quaternion
 from .ray import Ray
 from .transform import Transform

--- a/spatial/euler/axes.py
+++ b/spatial/euler/axes.py
@@ -8,6 +8,8 @@ from typing import List
 
 from spatial.vector3 import Vector3
 
+from ..parameters import parameters
+
 
 class Axes(enum.Enum):
     """All the different types of Euler angles."""
@@ -68,7 +70,9 @@ class Axes(enum.Enum):
         The function was created by solving each different Euler angle and then looking at the
         pattern although there is probably a nice mathematical basis for this.
         """
-        assert math.isclose(quaternion.norm(), 1), "The quaternion must be normalized"
+        assert math.isclose(
+            quaternion.norm(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]
+        ), "The quaternion must be normalized"
 
         # The indices of the axes used (e.g., YZY => 2, 3).
         first_letter: int = ord(self.name[0]) - ord("X") + 1
@@ -120,7 +124,9 @@ class Axes(enum.Enum):
 
         See the notes in the `Axes._proper` function.
         """
-        assert math.isclose(quaternion.norm(), 1), "The quaternion must be normalized"
+        assert math.isclose(
+            quaternion.norm(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]
+        ), "The quaternion must be normalized"
 
         # The indices of the axes used (e.g., YZX => 2, 3, 1).
         first_letter: int = ord(self.name[0]) - ord("X") + 1

--- a/spatial/matrix4.py
+++ b/spatial/matrix4.py
@@ -2,6 +2,7 @@ import math
 from typing import Iterable
 
 from .dual import Dual
+from .parameters import parameters
 from .quaternion import Quaternion, conjugate
 from .transform import Transform
 from .vector3 import Vector3
@@ -28,11 +29,19 @@ class Matrix4:
     def from_basis(cls, x: Vector3, y: Vector3, z: Vector3, origin: Vector3 = None):
         """Construct a quaternion from three mutually perpendicular basis vectors."""
         assert all(
-            [x.is_perpendicular_to(y), y.is_perpendicular_to(z), z.is_perpendicular_to(x)]
+            [
+                x.is_perpendicular_to(y, tolerance=parameters["ASSERT_ABS_TOL"]),
+                y.is_perpendicular_to(z, tolerance=parameters["ASSERT_ABS_TOL"]),
+                z.is_perpendicular_to(x, tolerance=parameters["ASSERT_ABS_TOL"]),
+            ]
         ), "All basis vectors must be mutually perpendicular"
 
         assert all(
-            [math.isclose(x.length(), 1), math.isclose(y.length(), 1), math.isclose(z.length(), 1)]
+            [
+                math.isclose(x.length(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]),
+                math.isclose(y.length(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]),
+                math.isclose(z.length(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]),
+            ]
         ), "All basis vectors must be unit length"
 
         o = origin or Vector3()

--- a/spatial/matrix4.py
+++ b/spatial/matrix4.py
@@ -1,11 +1,10 @@
-import math
 from typing import Iterable
 
 from .dual import Dual
 from .parameters import parameters
 from .quaternion import Quaternion, conjugate
 from .transform import Transform
-from .vector3 import Vector3
+from .vector3 import Vector3, is_orthonormal_basis
 
 
 class Matrix4:
@@ -28,21 +27,9 @@ class Matrix4:
     @classmethod
     def from_basis(cls, x: Vector3, y: Vector3, z: Vector3, origin: Vector3 = None):
         """Construct a quaternion from three mutually perpendicular basis vectors."""
-        assert all(
-            [
-                x.is_perpendicular_to(y, tolerance=parameters["ASSERT_ABS_TOL"]),
-                y.is_perpendicular_to(z, tolerance=parameters["ASSERT_ABS_TOL"]),
-                z.is_perpendicular_to(x, tolerance=parameters["ASSERT_ABS_TOL"]),
-            ]
-        ), "All basis vectors must be mutually perpendicular"
-
-        assert all(
-            [
-                math.isclose(x.length(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]),
-                math.isclose(y.length(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]),
-                math.isclose(z.length(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]),
-            ]
-        ), "All basis vectors must be unit length"
+        assert is_orthonormal_basis(
+            x, y, z, tolerance=parameters["ASSERT_ABS_TOL"]
+        ), "All basis vectors must be mutually perpendicular and of unit length"
 
         o = origin or Vector3()
         return cls([x.x, x.y, x.z, 0, y.x, y.y, y.z, 0, z.x, z.y, z.z, 0, o.x, o.y, o.z, 1])

--- a/spatial/parameters.py
+++ b/spatial/parameters.py
@@ -1,0 +1,1 @@
+parameters = {"ASSERT_ABS_TOL": 0.0001}

--- a/spatial/parameters.py
+++ b/spatial/parameters.py
@@ -1,1 +1,1 @@
-parameters = {"ASSERT_ABS_TOL": 0.0001}
+parameters = {"ABS_TOL": 0.00001, "ASSERT_ABS_TOL": 0.0001}

--- a/spatial/quaternion.py
+++ b/spatial/quaternion.py
@@ -2,6 +2,7 @@ import math
 from typing import List, Union
 
 from .euler import Axes, Order
+from .parameters import parameters
 from .swizzler import Swizzler
 from .vector3 import Vector3
 
@@ -32,7 +33,11 @@ class Quaternion(Swizzler):
     def from_basis(cls, x: Vector3, y: Vector3, z: Vector3):
         """Construct a quaternion from three mutually perpendicular basis vectors."""
         assert all(
-            [x.is_perpendicular_to(y), y.is_perpendicular_to(z), z.is_perpendicular_to(x)]
+            [
+                x.is_perpendicular_to(y, tolerance=parameters["ASSERT_ABS_TOL"]),
+                y.is_perpendicular_to(z, tolerance=parameters["ASSERT_ABS_TOL"]),
+                z.is_perpendicular_to(x, tolerance=parameters["ASSERT_ABS_TOL"]),
+            ]
         ), "All basis vectors must be mutually perpendicular"
 
         # Implementing the algorithm described in "Converting a Rotation Matrix to a Quaternion" by
@@ -217,8 +222,8 @@ def slerp(q1: Quaternion, q2: Quaternion, alpha: float, shortest_path: bool = Tr
     By default, the function follows the shortest path.
     """
     assert 0 <= alpha <= 1, "Interpolation value must be between 0 and 1"
-    assert math.isclose(q1.norm(), 1) and math.isclose(
-        q2.norm(), 1
+    assert math.isclose(q1.norm(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]) and math.isclose(
+        q2.norm(), 1, abs_tol=parameters["ASSERT_ABS_TOL"]
     ), "Both quaternions must be unit length"
 
     dot = q1.dot(q2)

--- a/spatial/quaternion.py
+++ b/spatial/quaternion.py
@@ -4,7 +4,7 @@ from typing import List, Union
 from .euler import Axes, Order
 from .parameters import parameters
 from .swizzler import Swizzler
-from .vector3 import Vector3
+from .vector3 import Vector3, is_orthonormal_basis
 
 
 class Quaternion(Swizzler):
@@ -32,13 +32,9 @@ class Quaternion(Swizzler):
     @classmethod
     def from_basis(cls, x: Vector3, y: Vector3, z: Vector3):
         """Construct a quaternion from three mutually perpendicular basis vectors."""
-        assert all(
-            [
-                x.is_perpendicular_to(y, tolerance=parameters["ASSERT_ABS_TOL"]),
-                y.is_perpendicular_to(z, tolerance=parameters["ASSERT_ABS_TOL"]),
-                z.is_perpendicular_to(x, tolerance=parameters["ASSERT_ABS_TOL"]),
-            ]
-        ), "All basis vectors must be mutually perpendicular"
+        assert is_orthonormal_basis(
+            x, y, z, tolerance=parameters["ASSERT_ABS_TOL"]
+        ), "All basis vectors must be mutually perpendicular and of unit length"
 
         # Implementing the algorithm described in "Converting a Rotation Matrix to a Quaternion" by
         # Mike Day, Insomniac Games

--- a/spatial/vector3.py
+++ b/spatial/vector3.py
@@ -1,6 +1,9 @@
 import math
-from typing import Union, overload
+from typing import Optional, Union, overload
 
+from spatial import parameters
+
+from .parameters import parameters
 from .swizzler import Swizzler
 
 
@@ -132,8 +135,9 @@ class Vector3(Swizzler):
 
         return NotImplemented
 
-    def is_perpendicular_to(self, other: "Vector3", tolerance: float = 0.00001) -> bool:
+    def is_perpendicular_to(self, other: "Vector3", tolerance: Optional[float] = None) -> bool:
         """Return True if the vector is perpendicular to the other vector."""
+        tolerance = tolerance or parameters["ABS_TOL"]
         return math.isclose(self * other, 0, abs_tol=tolerance)
 
     def is_unit(self, tolerance: float = 0.00001) -> bool:
@@ -160,11 +164,13 @@ class Vector3(Swizzler):
         return self
 
 
-def almost_equal(v1: Vector3, v2: Vector3, tol=0.00001) -> bool:
+def almost_equal(v1: Vector3, v2: Vector3, tolerance: Optional[float] = None) -> bool:
     """Return True if two vectors are equal within a given tolerance."""
+    tolerance = tolerance or parameters["ABS_TOL"]
+
     difference = v1 - v2
 
-    return math.isclose(difference.length_sq(), 0.0, abs_tol=tol)
+    return math.isclose(difference.length_sq(), 0.0, abs_tol=tolerance)
 
 
 def angle_between(v1: Vector3, v2: Vector3) -> float:
@@ -180,8 +186,12 @@ def cross(v1: Vector3, v2: Vector3) -> Vector3:
     return Vector3(v1.y * v2.z - v1.z * v2.y, v1.z * v2.x - v1.x * v2.z, v1.x * v2.y - v1.y * v2.x)
 
 
-def is_orthonormal_basis(x: Vector3, y: Vector3, z: Vector3, tolerance: float = 0.00001) -> bool:
+def is_orthonormal_basis(
+    x: Vector3, y: Vector3, z: Vector3, tolerance: Optional[float] = None
+) -> bool:
     """Return True if the three vectors are of unit length and mutually perpendicular."""
+    tolerance = tolerance or parameters["ABS_TOL"]
+
     are_perpendicular = all(
         [
             x.is_perpendicular_to(y, tolerance=tolerance),

--- a/spatial/vector3.py
+++ b/spatial/vector3.py
@@ -180,6 +180,27 @@ def cross(v1: Vector3, v2: Vector3) -> Vector3:
     return Vector3(v1.y * v2.z - v1.z * v2.y, v1.z * v2.x - v1.x * v2.z, v1.x * v2.y - v1.y * v2.x)
 
 
+def is_orthonormal_basis(x: Vector3, y: Vector3, z: Vector3, tolerance: float = 0.00001) -> bool:
+    """Return True if the three vectors are of unit length and mutually perpendicular."""
+    are_perpendicular = all(
+        [
+            x.is_perpendicular_to(y, tolerance=tolerance),
+            y.is_perpendicular_to(z, tolerance=tolerance),
+            z.is_perpendicular_to(x, tolerance=tolerance),
+        ]
+    )
+
+    are_unit_length = all(
+        [
+            math.isclose(x.length(), 1, abs_tol=tolerance),
+            math.isclose(y.length(), 1, abs_tol=tolerance),
+            math.isclose(z.length(), 1, abs_tol=tolerance),
+        ]
+    )
+
+    return are_perpendicular and are_unit_length
+
+
 def normalize(v: Vector3) -> Vector3:
     """Return the vector normalized to unit length.
 

--- a/test/test_vector3.py
+++ b/test/test_vector3.py
@@ -1,7 +1,14 @@
 import math
 import unittest
 
-from spatial.vector3 import Vector3, almost_equal, angle_between, cross, normalize
+from spatial.vector3 import (
+    Vector3,
+    almost_equal,
+    angle_between,
+    cross,
+    is_orthonormal_basis,
+    normalize,
+)
 
 
 class TestVector3(unittest.TestCase):
@@ -146,6 +153,16 @@ class TestVector3(unittest.TestCase):
         expected = Vector3(-9, -3, 1)
         self.assertAlmostEqual(cross(self.v1, self.v2), expected)
         self.assertAlmostEqual(cross(self.v2, self.v1), -expected)
+
+    def test_vector3_is_orthonormal_basis_returns_true_for_an_orthonormal_basis(self) -> None:
+        basis = [Vector3.X(), Vector3.Y(), Vector3.Z()]
+        self.assertTrue(is_orthonormal_basis(*basis))
+
+        basis = [2 * Vector3.X(), Vector3.Y(), Vector3.Z()]
+        self.assertFalse(is_orthonormal_basis(*basis))
+
+        basis = [Vector3(1, 1, 0).normalize(), Vector3.Y(), Vector3.Z()]
+        self.assertFalse(is_orthonormal_basis(*basis))
 
     def test_vector3_normalize_returns_the_normalized_vector(self) -> None:
         result = normalize(self.v1)


### PR DESCRIPTION
Version 0.6.3:

- Implement `vector3.is_orthonormal_basis` function.
- Implement parameters to control comparison tolerances throughout the library.
- Switch to `venv` (from `conda`).